### PR TITLE
Roadmap: turn milestone names into links

### DIFF
--- a/documentation/1.1/roadmap.md
+++ b/documentation/1.1/roadmap.md
@@ -30,15 +30,15 @@ However, our roadmap is quite well-defined:
 <div id="milestones-progress">
     <div id="milestone-overall">Loading…</div>
     <h3>Detail</h3>
-    <div data-title="Typechecker / language specification" data-milestone="https://api.github.com/repos/ceylon/ceylon-spec/milestones/11?callback=?">Loading…</div>
-    <div data-title="JVM compiler / documentation compiler" data-milestone="https://api.github.com/repos/ceylon/ceylon-compiler/milestones/11?callback=?">Loading…</div>
-    <div data-title="JS compiler" data-milestone="https://api.github.com/repos/ceylon/ceylon-js/milestones/8?callback=?">Loading…</div>
-    <div data-title="Language module" data-milestone="https://api.github.com/repos/ceylon/ceylon.language/milestones/10?callback=?">Loading…</div>
-    <div data-title="Module resolver" data-milestone="https://api.github.com/repos/ceylon/ceylon-module-resolver/milestones/10?callback=?">Loading…</div>
-    <div data-title="Runtime" data-milestone="https://api.github.com/repos/ceylon/ceylon-runtime/milestones/11?callback=?">Loading…</div>
-    <div data-title="Common" data-milestone="https://api.github.com/repos/ceylon/ceylon-common/milestones/7?callback=?">Loading…</div>
-    <div data-title="IDE" data-milestone="https://api.github.com/repos/ceylon/ceylon-ide-eclipse/milestones/11?callback=?">Loading…</div>
-    <div data-title="SDK" data-milestone="https://api.github.com/repos/ceylon/ceylon-sdk/milestones/8?callback=?">Loading…</div>
-    <div data-title="Formatter" data-milestone="https://api.github.com/repos/ceylon/ceylon.formatter/milestones/6?callback=?">Loading…</div>
+    <div data-title="Typechecker / language specification" data-repo="ceylon-spec" data-milestone="11">Loading…</div>
+    <div data-title="JVM compiler / documentation compiler" data-repo="ceylon-compiler" data-milestone="11">Loading…</div>
+    <div data-title="JS compiler" data-repo="ceylon-js" data-milestone="8">Loading…</div>
+    <div data-title="Language module" data-repo="ceylon.language" data-milestone="10">Loading…</div>
+    <div data-title="Module resolver" data-repo="ceylon-module-resolver" data-milestone="10">Loading…</div>
+    <div data-title="Runtime" data-repo="ceylon-runtime" data-milestone="11">Loading…</div>
+    <div data-title="Common" data-repo="ceylon-common" data-milestone="7">Loading…</div>
+    <div data-title="IDE" data-repo="ceylon-ide-eclipse" data-milestone="11">Loading…</div>
+    <div data-title="SDK" data-repo="ceylon-sdk" data-milestone="8">Loading…</div>
+    <div data-title="Formatter" data-repo="ceylon.formatter" data-milestone="6">Loading…</div>
 </div>
 

--- a/js/common.js
+++ b/js/common.js
@@ -162,20 +162,20 @@ function addTryButtons(){
 
 // Roadmap
 
-function loadMilestone(div, title, json){
+function loadMilestone(div, title, json, repo){
     var open = json.data.open_issues;
     var closed = json.data.closed_issues;
     var percentage = 100 * closed / (open + closed);
     var milestone = json.data.title;
-    makeMilestoneDiv(div, title, open, closed, milestone);
+    makeMilestoneDiv(div, title, open, closed, milestone, repo);
 }
 
-function makeMilestoneDiv(div, title, open, closed, milestone){
+function makeMilestoneDiv(div, title, open, closed, milestone, repo){
 	var percentage = 100 * closed / (open + closed);
 	div.empty();
 	
 	if(title != null){
-		jQuery("<div/>").addClass("title").text(title + ": " + milestone).appendTo(div);
+		jQuery("<div/>").addClass("title").text(title + ": ").append(jQuery("<a/>").attr("href", "https://github.com/ceylon/" + repo + "/milestones/" + milestone).text(milestone)).appendTo(div)
 	}
 	jQuery("<div/>").addClass("count").text("closed: " + closed + " — open: " + open).appendTo(div);
 
@@ -196,12 +196,14 @@ jQuery(function (){
 	jQuery("div[data-milestone]").each(function (index, elem){
 		var $elem = jQuery(elem);
         var title = $elem.attr("data-title");
-		var url = $elem.attr("data-milestone");
+		var repo = $elem.attr("data-repo");
+		var milestone = $elem.attr("data-milestone");
+		var url = "https://api.github.com/repos/ceylon/" + repo + "/milestones/" + milestone + "?callback=?";
 		makeMilestoneDiv($elem, title, 100, 0, "M6");
 		jQuery.getJSON(url, function(json){
 		    open_total += json.data.open_issues;
 		    closed_total += json.data.closed_issues;
-			loadMilestone($elem, title, json);
+			loadMilestone($elem, title, json, repo);
 			makeMilestoneDiv($overall, null, open_total, closed_total);
 		});
 	});


### PR DESCRIPTION
The milestone names ("1.3", "1.3.0") are turned into links to the Github milestone page, allowing users to easily see all open issues.