### PR TITLE
Fix copy+paste error in unary plus reference

### DIFF
--- a/documentation/1.1/reference/operator/unary_plus.md
+++ b/documentation/1.1/reference/operator/unary_plus.md
@@ -42,7 +42,7 @@ The meaning of `+` depends on
 
 ### Type
 
-The result type of the `-` operator is the same as the `Invertible` type of its operand.
+The result type of the `+` operator is the same as the `Invertible` type of its operand.
 
 ### Meaning of unary plus for built-in types
 


### PR DESCRIPTION
See also #341.

Note: another open question, which this PR doesn’t address, is whether the preceding sentence is still correct:

> The unary `+` operator is [polymorphic](#{page.doc_root}/reference/operator/operator-polymorphism). The meaning of `+` depends on [`Invertible`](#{site.urls.apidoc_1_1}/Invertible.type.html) interface

It’s still *kinda* polymorphic, since `+x` is only legal for `Invertible x`, but the result/meaning doesn’t depend on the implementation of `x` – it’s always simply `x`.