### PR TITLE
Fix reference to deleted function

### DIFF
--- a/documentation/1.1/tour/sequences.md
+++ b/documentation/1.1/tour/sequences.md
@@ -336,12 +336,12 @@ shown above.
 
 <!-- try:
     String[] operators = [ "+", "-", "*", "/" ];
-    for (i -> op in entries(operators)) {
+    for (i -> op in operators.indexed) {
         // ...
     }
 -->
 <!-- cat: void m(String operators) { -->
-    for (i -> op in entries(operators)) {
+    for (i -> op in operators.indexed) {
         // ...
     }
 <!-- cat: } -->


### PR DESCRIPTION
I think this fix is missing from c22a4b3.

This came up on the ceylon-users mailing list: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/ceylon-users/PPzRaDe-H80/hbIfT5dbCQAJ