### PR TITLE
Minor change due to Range being an abstract class nowadays

### DIFF
--- a/documentation/1.2/tour/sequences.md
+++ b/documentation/1.2/tour/sequences.md
@@ -204,7 +204,8 @@ so we can iterate a `Sequential` using a `for` loop:
 ## Ranges
 
 A [`Range`](#{site.urls.apidoc_1_2}/Range.type.html)
-is a kind of `Sequence`. The following:
+is a kind of `Sequence`. The [`span`](#{site.urls.apidoc_1_2}/index.html#span)
+function creates a `Range`. The following:
 
 <!-- try:
     Character[] uppercaseLetters = 'A'..'Z';
@@ -218,13 +219,13 @@ is a kind of `Sequence`. The following:
 Is just sugar for:
 
 <!-- try:
-    Sequential<Character> uppercaseLetters = Range('A','Z');
-    Sequential<Integer> countDown = Range(10,0);
+    Sequential<Character> uppercaseLetters = span('A','Z');
+    Sequential<Integer> countDown = span(10,0);
     print(uppercaseLetters);
     print(countDown);
 -->
-    Sequential<Character> uppercaseLetters = Range('A','Z');
-    Sequential<Integer> countDown = Range(10,0);
+    Sequential<Character> uppercaseLetters = span('A','Z');
+    Sequential<Integer> countDown = span(10,0);
 
 In fact, this is just a sneak preview of the fact that almost all operators 
 in Ceylon are just sugar for method calls upon a type. We'll come back to this 

--- a/documentation/1.2/tour/typeinference.md
+++ b/documentation/1.2/tour/typeinference.md
@@ -318,7 +318,7 @@ There's two idioms that we could use to handle this situation. The first uses
 a "wrapper" object for each entry:
 
 <!-- try: -->
-    class Maybe(Item? item) {}
+    class Maybe(shared Item? item) {}
     Map<String,Maybe<Item>> map 
             = HashMap<String,Maybe<Item>>();
     

--- a/documentation/1.2/tour/typeinference.md
+++ b/documentation/1.2/tour/typeinference.md
@@ -251,7 +251,7 @@ As is the following code:
 
 What about iterables that produce `null`s? Well, do you 
 [remember](../basics#dealing_with_objects_that_arent_there) the type of 
-`null` was [`Null`](#{site.urls.apidoc_1_2}/Nothing.type.html)?
+`null` was [`Null`](#{site.urls.apidoc_1_2}/Null.type.html)?
 
 <!-- try-post:
     print(str);


### PR DESCRIPTION
BTW: The documentation for class Range mentions functions makeSpan() and makeMeasure(), but the corresponding links point to span() and measure(). I guess these functions were renamed and the old names somehow survived in the doc comments...