### PR TITLE
Update issues page for OBR and IDEs

### DIFF
--- a/code/issues.md
+++ b/code/issues.md
@@ -12,14 +12,12 @@ an enhancement proposal, open an issue.
 
 There is a dedicated issue tracker for:
 
-- [the parser, typechecker, and language specification](https://github.com/ceylon/ceylon-spec/issues), 
-- [the compiler and documentation compiler](https://github.com/ceylon/ceylon-compiler/issues),
-- [the JavaScript compiler](https://github.com/ceylon/ceylon-js/issues),
-- [Ceylon IDE](https://github.com/ceylon/ceylon-ide-eclipse/issues),
-- [the Ceylon language module](https://github.com/ceylon/ceylon.language/issues),
-- [the platform modules](https://github.com/ceylon/ceylon-sdk/issues) belonging to the Ceylon SDK,
-- [the Ceylon module system](https://github.com/ceylon/ceylon-module-resolver/issues),
-- [the Ceylon launcher](https://github.com/ceylon/ceylon-runtime/issues),
+- [the distribution: compiler, runtime, language module, specification](https://github.com/ceylon/ceylon/issues),
+- the IDE:
+  - [the Eclipse-based IDE](https://github.com/ceylon/ceylon-ide-eclipse),
+  - [the work-in-progress IntelliJ-based IDE](https://github.com/ceylon/ceylon-ide-intellij), and
+  - [common components for both IDEs](https://github.com/ceylon/ceylon-ide-common) (when in doubt, open an issue for a specific IDE, and it may be moved here if applicable),
+- [the platform modules](https://ceylon/ceylon-sdk/issues) belonging to the Ceylon SDK,
 - [Ceylon Herd](https://github.com/ceylon/ceylon-herd/issues), and
 - [this website](https://github.com/ceylon/ceylon-lang.org/issues).
 


### PR DESCRIPTION
(We might also want to remove the link to the known-issues page, since we’re not *actually* maintaining it, but that’s separate.)