### PR TITLE
Fix Vert.x links.

### DIFF
--- a/documentation/1.1/index.md
+++ b/documentation/1.1/index.md
@@ -57,7 +57,7 @@ There's even [Vim support](resources/vim) available.
 
 ## Vert.x
 
-There is [extensive documentation](http://vertx.io/core_manual_ceylon.html) 
+There is [extensive documentation](http://vertx.io/docs/vertx-core/ceylon/)
 for using Ceylon on Vert.x.
 
 ## Got questions? We have FAQs

--- a/documentation/1.1/introduction.md
+++ b/documentation/1.1/introduction.md
@@ -25,7 +25,7 @@ is equally at home on Java and JavaScript virtual machines.
 Ceylon modules may be deployed on Ceylon's own JVM-based module runtime,
 on any OSGi container, on the 
 [Node.js module system](http://nodejs.org/api/modules.html), on 
-[Vert.x](http://vertx.io/core_manual_ceylon.html#vertx-for-ceylon), or
+[Vert.x](http://vertx.io/docs/vertx-core/ceylon/), or
 in a browser using [require.js](http://requirejs.org/).
 
 When cross-platform execution is not a priority, Ceylon is designed to 

--- a/documentation/1.2/index.md
+++ b/documentation/1.2/index.md
@@ -58,7 +58,7 @@ There's even [Vim support](resources/vim) available.
 
 ## Vert.x
 
-There is [extensive documentation](http://vertx.io/core_manual_ceylon.html) 
+There is [extensive documentation](http://vertx.io/docs/vertx-core/ceylon/)
 for using Ceylon on Vert.x.
 
 ## Got questions? We have FAQs

--- a/documentation/1.2/introduction.md
+++ b/documentation/1.2/introduction.md
@@ -25,7 +25,7 @@ is equally at home on Java and JavaScript virtual machines.
 Ceylon modules may be deployed on Ceylon's own JVM-based module runtime,
 on any OSGi container, on the 
 [Node.js module system](http://nodejs.org/api/modules.html), on 
-[Vert.x](http://vertx.io/core_manual_ceylon.html#vertx-for-ceylon), or in 
+[Vert.x](http://vertx.io/docs/vertx-core/ceylon/), or in 
 a browser using [require.js](http://requirejs.org/).
 
 When cross-platform execution is not a priority, Ceylon is designed to 


### PR DESCRIPTION
The Ceylon Core Manual for Vert.x appears to have moved.