### PR TITLE
Fixes for OSGi documentation

### DIFF
--- a/documentation/1.2/reference/interoperability/osgi.md
+++ b/documentation/1.2/reference/interoperability/osgi.md
@@ -27,36 +27,36 @@ These bundles are available in a dedicated place on the Ceylon language web site
 - as __OBR bundle repositories__:
     - Old-style OBR syntax (still used by Apache Felix):
         
-        https://downloads.ceylon-lang.org/osgi/distribution/1.2.2/repository.xml
+        [https://downloads.ceylon-lang.org/osgi/distribution/1.2.2/repository.xml](https://downloads.ceylon-lang.org/osgi/distribution/1.2.2/repository.xml)
 
-        https://downloads.ceylon-lang.org/osgi/sdk/1.2.2/repository.xml
+        [https://downloads.ceylon-lang.org/osgi/sdk/1.2.2/repository.xml](https://downloads.ceylon-lang.org/osgi/sdk/1.2.2/repository.xml)
 
     - New standard R5 OBR syntax:
         
-        https://downloads.ceylon-lang.org/osgi/distribution/1.2.2/index.xml
+        [https://downloads.ceylon-lang.org/osgi/distribution/1.2.2/index.xml](https://downloads.ceylon-lang.org/osgi/distribution/1.2.2/index.xml)
         
-        https://downloads.ceylon-lang.org/osgi/sdk/1.2.2/index.xml
+        [https://downloads.ceylon-lang.org/osgi/sdk/1.2.2/index.xml](https://downloads.ceylon-lang.org/osgi/sdk/1.2.2/index.xml)
 
 - as __P2 repositories for Eclipse development__ :
   
-  https://downloads.ceylon-lang.org/osgi/distribution/1.2.2/
+  [https://downloads.ceylon-lang.org/osgi/distribution/1.2.2/](https://downloads.ceylon-lang.org/osgi/distribution/1.2.2/)
 
-  https://downloads.ceylon-lang.org/osgi/sdk/1.2.2/
+  [https://downloads.ceylon-lang.org/osgi/sdk/1.2.2/](https://downloads.ceylon-lang.org/osgi/sdk/1.2.2/)
 
 - as __Zip archives for direct deployment inside containers__ :
   
-  https://downloads.ceylon-lang.org/osgi/distribution/1.2.2/ceylon.distribution.osgi.bundles-1.2.2.zip
+  [https://downloads.ceylon-lang.org/osgi/distribution/1.2.2/ceylon.distribution.osgi.bundles-1.2.2.zip](https://downloads.ceylon-lang.org/osgi/distribution/1.2.2/ceylon.distribution.osgi.bundles-1.2.2.zip)
   
-  https://downloads.ceylon-lang.org/osgi/sdk/1.2.2/ceylon.sdk.osgi.bundles-1.2.2.zip
+  [https://downloads.ceylon-lang.org/osgi/sdk/1.2.2/ceylon.sdk.osgi.bundles-1.2.2.zip](https://downloads.ceylon-lang.org/osgi/sdk/1.2.2/ceylon.sdk.osgi.bundles-1.2.2.zip)
 
 - as __Apache Karaf (aka JBoss Fuse) [features](http://karaf.apache.org/manual/latest/users-guide/provisioning.html)__:
     - `ceylon.distribution.runtime`, available in the following feature repository
     
-        https://downloads.ceylon-lang.org/osgi/distribution/1.2.2/karaf-features.xml
+        [https://downloads.ceylon-lang.org/osgi/distribution/1.2.2/karaf-features.xml](https://downloads.ceylon-lang.org/osgi/distribution/1.2.2/karaf-features.xml)
     
     - `ceylon.sdk`, available in the following feature repository
       
-        https://downloads.ceylon-lang.org/osgi/distribution/1.2.2/karaf-features.xml
+        [https://downloads.ceylon-lang.org/osgi/distribution/1.2.2/karaf-features.xml](https://downloads.ceylon-lang.org/osgi/distribution/1.2.2/karaf-features.xml)
 
 #### Installing the Ceylon Distribution and SDK in an OSGI container
 
@@ -66,9 +66,9 @@ These bundles are available in a dedicated place on the Ceylon language web site
 
 2. In the `conf/config.properties` file of the Felix installation directory, add the following property:
 
-        org.osgi.framework.executionenvironment=J2SE-1.7,JavaSE-1.7,J2SE-1.6,JavaSE-1.6,J2SE-1.5,JavaSE-1.5,J2SE-1.4,JavaSE-1.4,J2SE-1.3,JavaSE-1.3,J2SE-1.2,,JavaSE-1.2,CDC-1.1/Foundation-1.1,CDC-1.0/Foundation-1.0,J2ME,OSGi/Minimum-1.1,OSGi/Minimum-1.0
+       org.osgi.framework.executionenvironment=J2SE-1.7,JavaSE-1.7,J2SE-1.6,JavaSE-1.6,J2SE-1.5,JavaSE-1.5,J2SE-1.4,JavaSE-1.4,J2SE-1.3,JavaSE-1.3,J2SE-1.2,,JavaSE-1.2,CDC-1.1/Foundation-1.1,CDC-1.0/Foundation-1.0,J2ME,OSGi/Minimum-1.1,OSGi/Minimum-1.0
 
-  This is necessary since by default the Felix OSGI container provided execution environments don't include `J2SE-1.7`, which is required by a transitive dependency of the `ceylon.net` module.
+   This is necessary since by default the Felix OSGI container provided execution environments don't include `J2SE-1.7`, which is required by a transitive dependency of the `ceylon.net` module.
 
 3. In the `conf/config.properties` file of the Felix installation directory, find the `obr.repository.url` property.
 
@@ -76,19 +76,19 @@ These bundles are available in a dedicated place on the Ceylon language web site
 
 5. Add the 2 Ceylon following OBR urls at the end of this property (space-separated):
  
-        https://downloads.ceylon-lang.org/osgi/distribution/1.2.2/repository.xml https://downloads.ceylon-lang.org/osgi/sdk/1.2.2/repository.xml
+       https://downloads.ceylon-lang.org/osgi/distribution/1.2.2/repository.xml https://downloads.ceylon-lang.org/osgi/sdk/1.2.2/repository.xml
 
 6. From the Felix installation directory, Start Felix with the following command:
 
-        java -jar bin/felix.jar
+       java -jar bin/felix.jar
 
 7. From the Felix Gogo shell, deploy the Ceylon Distribution with:
       
-        obr:deploy "Ceylon Distribution Bundle"
+       obr:deploy "Ceylon Distribution Bundle"
 
 8. Deploy any SDK module you need with the following command:
       
-        obr:deploy ceylon.file
+       obr:deploy ceylon.file
 
 ##### Glassfish v4.1:
 
@@ -99,15 +99,15 @@ Let's assume we start with a fresh installation of Glassfish v4.1
 
 1. Unzip the 2 zip archives mentioned earlier ([distribution](https://downloads.ceylon-lang.org/osgi/distribution/1.2.2/ceylon.distribution.osgi.bundles-1.2.2.zip) and [sdk](https://downloads.ceylon-lang.org/osgi/sdk/1.2.2/ceylon.sdk.osgi.bundles-1.2.2.zip)) into :
 
-  `../glassfish4/glassfish/domains/domain1/autodeploy/bundles`
+   `../glassfish4/glassfish/domains/domain1/autodeploy/bundles`
   
 2. start the glassfish server :
 
-  `../glassfish4/bin/asadmin start-domain`
+   `../glassfish4/bin/asadmin start-domain`
 
 3. verify that the various Ceylon bundles were deployed correctly in the following log file :
 
-  `../glassfish4/glassfish/domains/domain1/logs`
+   `../glassfish4/glassfish/domains/domain1/logs`
 
 ##### Apache Karaf 4.0.4 (Karaf is a part of JBoss Fuse) with Karaf features:
 
@@ -115,20 +115,20 @@ Let's assume we start with a fresh installation of Glassfish v4.1
 
 2. In the karaf installation directory, start Karaf with the following command:
 
-        ./bin/karaf
+       ./bin/karaf
 
 3. In the karaf shell, add the Ceylon distribution feature repository with the following command:
 
-        feature:repo-add https://downloads.ceylon-lang.org/osgi/distribution/1.2.2/karaf-features.xml
+       feature:repo-add https://downloads.ceylon-lang.org/osgi/distribution/1.2.2/karaf-features.xml
 
 4. In the karaf shell, add the Ceylon SDK feature repository with the following command:
 
-        feature:repo-add https://downloads.ceylon-lang.org/osgi/sdk/1.2.2/karaf-features.xml
+       feature:repo-add https://downloads.ceylon-lang.org/osgi/sdk/1.2.2/karaf-features.xml
 
 5. In the karaf shell, install the Ceylon distribution feature with the following command:
 
-        feature:install ceylon.distribution.runtime
+       feature:install ceylon.distribution.runtime
 
 6. In the karaf shell, install the Ceylon SDK feature with the following command:
 
-        feature:install ceylon.sdk
+       feature:install ceylon.sdk

--- a/documentation/1.2/tour/interop.md
+++ b/documentation/1.2/tour/interop.md
@@ -86,23 +86,25 @@ Aether. You can find more information [here](../../reference/repository/maven).
 ## Deploying Ceylon on OSGi
 
 Ceylon is fully interoperable with OSGI, so that Ceylon modules:
+
 - can be deployed as pure OSGI bundles in an OSGI container out-of-the-box without any modification of the module archive file,
 - can embed additional OSGI metadata, to declare services for example,
 - can easily use OSGI standard services
 
-This provides a great and straightforward opportunity to run Ceylon code inside a growing number of JEE application servers or enterprise containers that are base upon (or integrated with) OSGI.
+This provides a great and straightforward opportunity to run Ceylon code inside a growing number of JEE application servers or enterprise containers that are based upon (or integrated with) OSGI.
 
 #### Installing the Ceylon distribution / Ceylon SDK in an OSGI container
 
 In order to be able to resolve and start Ceylon module archives (`.car` files) inside an OSGI container, you will first need to install, in the OSGI container, all the bundles of the Ceylon distribution and SDK.
 
 These bundles are available in a dedicated location on the Ceylon language web site under various delivery forms:
+
 - OSGI bundle repositories (OBR and R5 XML), for Felix-based containers for example,
 - P2 repositories for Eclipse development or deployment to an Equinox container,
 - Zip archives for direct deployment inside containers,
 - Apache Karaf (aka JBoss Fuse) [features](http://karaf.apache.org/manual/latest/users-guide/provisioning.html)
 
-The OSGI interoperability reference gives more details about the [URLs providing these packages](../../reference/interoperability/osgi.md#retrieving-the-ceylon-distribution-and-sdk-for-osgi), as well as [how to install](../../reference/interoperability/osgi.md#installing-the-ceylon-distribution-and-sdk-in-an-osgi-container) these bundles, for various containers
+The OSGI interoperability reference gives more details about the [URLs providing these packages](../../reference/interoperability/osgi#retrieving_the_ceylon_distribution_and_sdk_for_osgi), as well as [how to install](../../reference/interoperability/osgi#installing_the_ceylon_distribution_and_sdk_in_an_osgi_container) these bundles, for various containers
 
 #### OSGI Metadata management
 
@@ -111,81 +113,78 @@ for execution on the Java virtual machine already contain the OSGI metadata that
 can be deduced from the Ceylon module descriptor.
 
 More precisely, for the following module descriptor:
-```Ceylon
-native("jvm") module example.pureCeylon "3.1.0" {
-    import ceylon.locale "1.2.2";
-    import java.base "7";
-    shared import ceylon.net "1.2.2";
-}
-```
+
+    native("jvm") module example.pureCeylon "3.1.0" {
+        import ceylon.locale "1.2.2";
+        import java.base "7";
+        shared import ceylon.net "1.2.2";
+    }
+
 the following OSGI metadata will be automatically generated in the module archive `META-INF/MANIFEST.MF` entry:
-```
-Bundle-SymbolicName: example.pureCeylon
-Bundle-Version: 3.1.0.v20160311-1742
-Export-Package: example.pureCeylon;version=3.1.0
-Require-Bundle: com.redhat.ceylon.dist;bundle-version=1.2.2;visibility
- :=reexport,ceylon.locale;bundle-version=1.2.2,ceylon.net;bundle-versi
- on=1.2.2;visibility:=reexport,ceylon.language;bundle-version=1.2.2;vi
- sibility:=reexport
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version>=1.7))"
-```
+
+    Bundle-SymbolicName: example.pureCeylon
+    Bundle-Version: 3.1.0.v20160311-1742
+    Export-Package: example.pureCeylon;version=3.1.0
+    Require-Bundle: com.redhat.ceylon.dist;bundle-version=1.2.2;visibility
+     :=reexport,ceylon.locale;bundle-version=1.2.2,ceylon.net;bundle-versi
+     on=1.2.2;visibility:=reexport,ceylon.language;bundle-version=1.2.2;vi
+     sibility:=reexport
+    Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version>=1.7))"
+
 The Ceylon module imports are translated into a `Require-Bundle` header, and `shared` imports are translated into a `reexport` directive.The `java.base "7"` import is translated into a `Require-Capability` header that requires the same Java version.
 
-Note that the `com.redhat.ceylon.dist` bundle is systematically and implicitely added as a dependency to all generated Ceylon archives.
+Note that the `com.redhat.ceylon.dist` bundle is systematically and implicitly added as a dependency to all generated Ceylon archives.
 
 However it is also possible to customize the OSGI metadata of the generated archive in 2 ways:
 
-1. Additional manifest entries or resources (such as a desclarative service descriptor) can be added by simply adding resources as explained [below](./interop.md#meta_inf_and_web_inf).
+1. Additional manifest entries or resources (such as a desclarative service descriptor) can be added by simply adding resources as explained [below](#meta_inf_and_web_inf).
 
 2. Module imports that correspond to __dependencies provided by the OSGI container__ (such as the OSGI framework bundle or any bundle assumed to be available in the OSGI container) should be omitted from the generated `Require-Bundle` header. The `--osgi-provided-bundles=<modules>` option of the `ceylon compile` command allows specifying those modules. The same list can also be specified in the [compiler section](http://www.ceylon-lang.org/documentation/1.2/reference/tool/config#_compiler_section) of the configuration file.
   
-  Generally, once omitted from the `Require-Bundle` header, the dependencies to provided bundles should be declared in an `Import-Package` header added in the [`MANIFEST.MF` resource](./interop.md#meta_inf_and_web_inf), as mentioned in point 1.
+  Generally, once omitted from the `Require-Bundle` header, the dependencies to provided bundles should be declared in an `Import-Package` header added in the [`MANIFEST.MF` resource](#meta_inf_and_web_inf), as mentioned in point 1.
  
 #### Ceylon Metamodel registering
 
 In order to be able to fully leverage the power of the Ceylon language, the metamodel should be initialized for each module used by a Ceylon application. It is automatically performed when running from the command line through the `ceylon run` command, but in an OSGi container it should be done when starting the Ceylon module. The Ceylon OSGI distribution provides an easy way to register the metamodel for a module, as well as for all the modules transitively imported.
 
-This can be done by adding an OSGI activator class to the Ceylon module, that performs this metamodel registration. The `com.redhat.ceylon.dist` OSGI bundle, implicitely required by all Ceylon modules, already provides such an activator class: `com.redhat.ceylon.dist.osgi.Activator`
+This can be done by adding an OSGI activator class to the Ceylon module, that performs this metamodel registration. The `com.redhat.ceylon.dist` OSGI bundle, implicitly required by all Ceylon modules, already provides such an activator class: `com.redhat.ceylon.dist.osgi.Activator`
 
-So if you don't need to do anything else in your OSGI Ceylon bundle at startup, you can simply add the following line to your [MANIFEST.MF resource](./interop.md#meta_inf_and_web_inf):
-```
-Bundle-Activator: com.redhat.ceylon.dist.osgi.Activator
-```
+So if you don't need to do anything else in your OSGI Ceylon bundle at startup, you can simply add the following line to your [MANIFEST.MF resource](#meta_inf_and_web_inf):
 
+    Bundle-Activator: com.redhat.ceylon.dist.osgi.Activator
 
 Alternatively, if you need to perform some sort initialization in your Ceylon module bundle startup, you can also define an `Activator` class that will delegate to the default `com.redhat.ceylon.dist.osgi.Activator`. In this case:
 
 1. Explicitly import the `com.redhat.ceylon.dist` module in your module descriptor:
-```Ceylon
-native("jvm") module example.withActivator "1.0.0" {
-    import com.redhat.ceylon.dist "1.2.2";
-    import java.base "7";
-}
-```
-2. Add the following class to your module:
-```Ceylon
-import com.redhat.ceylon.dist.osgi {
-    DefaultActivator = Activator
-}
-import org.osgi.framework {
-    BundleContext
-}
 
-shared class Activator() extends DefaultActivator() {
-    shared actual void start(BundleContext context) {
-        // do module startup stuff
-        super.start(context); // will perform the metamodel registering
-    }
-    shared actual void stop(BundleContext context) {
-        // do module shutdown stuff
-        super.stop(context);
-    }
-}
-```
+       native("jvm") module example.withActivator "1.0.0" {
+           import com.redhat.ceylon.dist "1.2.2";
+           import java.base "7";
+       }
+
+2. Add the following class to your module:
+
+       import com.redhat.ceylon.dist.osgi {
+           DefaultActivator = Activator
+       }
+       import org.osgi.framework {
+           BundleContext
+       }
+       
+       shared class Activator() extends DefaultActivator() {
+           shared actual void start(BundleContext context) {
+               // do module startup stuff
+               super.start(context); // will perform the metamodel registering
+           }
+           shared actual void stop(BundleContext context) {
+               // do module shutdown stuff
+               super.stop(context);
+           }
+       }
+
 3. Add the following line to your `example/withActivator/ROOT/META-INF/MANIFEST.MF` resource:
-```
-Bundle-Activator: example.withActivator.Activator
-```
+
+       Bundle-Activator: example.withActivator.Activator
 
 ## Interoperation with Java types
 


### PR DESCRIPTION
(This is a fixup for #398.)

Indentation was being interpreted incorrectly, there were some spelling errors, some links were broken, and ceylon-lang.org's Markdown processor doesn't support ```` ``` ```` code blocks or automatic links.

There's also a remaining problem: the code blocks get Try Online links. We can't currently remove those without breaking the markup, at least not without more work than I can put in right now.