### PR TITLE
update information about the unary plus

### DIFF
--- a/documentation/1.2/reference/operator/unary_plus.md
+++ b/documentation/1.2/reference/operator/unary_plus.md
@@ -26,30 +26,13 @@ Note that `+` does not change the sign of a negative number:
 
 ### Definition 
 
-The `+` operator is defined as follows:
-
-<!-- check:none -->
-<!-- try: -->
-    rhs.positiveValue;
+The `+` operator is a no-op.
 
 See the [language specification](#{site.urls.spec_current}#arithmetic) for more details.
 
-### Polymorphism
-
-The unary `+` operator is [polymorphic](#{page.doc_root}/reference/operator/operator-polymorphism). 
-The meaning of `+` depends on 
-[`Invertible`](#{site.urls.apidoc_1_2}/Invertible.type.html) interface 
-
 ### Type
 
-The result type of the `-` operator is the same as the `Invertible` type of its operand.
-
-### Meaning of unary plus for built-in types
-
-For the built-in numeric types
-[`Integer`](#{site.urls.apidoc_1_2}/Integer.type.html) and
-[`Float`](#{site.urls.apidoc_1_2}/Float.type.html), `+` 
-is essentially a no-op.
+The result type of the `+` operator is the same as the `Invertible` type of its operand.
 
 ## See also
 


### PR DESCRIPTION
In the past, the unary `+` used to be equivalent to `.positiveValue`. This is no longer true. `positiveValue` doesn’t even exist anymore!
