### PR TITLE
Improve anchor links

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -219,7 +219,7 @@ jQuery(function (){
  For example:
  
      <h2 id="a_really_simple_program">A <em>really</em> simple program</h2>
-     <h2 id="a_really_simple_program"><a class="anchor" href="http://localhost:4242/documentation/1.0/tour#a_really_simple_program">A <em>really</em> simple program</a></h2>
+     <h2 id="a_really_simple_program"><a class="anchor" href="#a_really_simple_program">A <em>really</em> simple program</a></h2>
  
  TODO: This should be done by the Markdown processor; see #308.
  */
@@ -234,7 +234,7 @@ jQuery(function($) {
         if(!anyLink) {
             var html = $elem.html();
             $elem.empty();
-            $elem.append($("<a>").attr("href", document.URL.replace(/\/?(\#.*)?$/, "") + '#' + $elem.attr("id")).attr("class", "anchor").html(html));
+            $elem.append($("<a>").attr("href", '#' + $elem.attr("id")).attr("class", "anchor").html(html));
         }
     });
 });


### PR DESCRIPTION
Instead of linking to the full URL + anchor, just link to the anchor. No need to reload the site for this. I suggested this in #432 and then didn’t do anything about it for months, and I don’t even know why I implemented the full URL version in #309 in the first place – you can see that the actual fix, aside from a comment update, is purely to remove some code – but anyways, it’s better now, so there we are.

---

Putting this up for review in case someone wants to look at it, but otherwise I’ll just merge this tomorrow or so.