### PR TITLE
shortcut syntax

### DIFF
--- a/documentation/1.2/tour/inheritance.md
+++ b/documentation/1.2/tour/inheritance.md
@@ -258,7 +258,7 @@ abbreviate the above code like this:
         
         value azimuth => pi*(angle/pi).fractionalPart;
         
-        shared actual Boolean equals(Object that) {
+        equals(Object that) {
             if (is Polar that) {
                 return azimuth==that.azimuth && 
                        radius==that.radius; 


### PR DESCRIPTION
shouldn't the shortcut syntax be defined on the 'equals' function as well?