### PR TITLE
Restored link to release announcement blog post

### DIFF
--- a/download-archive.html.haml
+++ b/download-archive.html.haml
@@ -287,7 +287,8 @@ author: Stef
 
 %p
  %a{ :href => "/blog/2017/03/03/ceylon-1-3-2/" }
- Ceylon 1.3.2 "Smile Tolerantly" is the latest 
+  Ceylon 1.3.2 "Smile Tolerantly"
+ is the latest 
  release of the language, command line tools and IDEs, but if 
  you need older versions of the Command-line distribution,
  you can find them all here.


### PR DESCRIPTION
Commit 99a65b8 removed the line break, which made the anchor empty. This change restores it. The alternative would be to remove the link altogether.