### PR TITLE
Grammar fix: Removed duplicate word

### DIFF
--- a/documentation/1.0/faq/language-design.md
+++ b/documentation/1.0/faq/language-design.md
@@ -250,7 +250,7 @@ goal of the language.
 
 The "best" default is the _most restrictive_ option. Otherwise,
 the developer of a module might accidently make something
-something shared that they don't intend to make shared, and
+shared that they don't intend to make shared, and
 be forced to either continue to support the 
 unintentionally-shared operation for the rest of the life of 
 the module, or break clients. There would be nothing the 

--- a/documentation/1.1/faq/language-design.md
+++ b/documentation/1.1/faq/language-design.md
@@ -313,7 +313,7 @@ goal of the language.
 
 The "best" default is the _most restrictive_ option. Otherwise,
 the developer of a module might accidently make something
-something shared that they don't intend to make shared, and
+shared that they don't intend to make shared, and
 be forced to either continue to support the 
 unintentionally-shared operation for the rest of the life of 
 the module, or break clients. There would be nothing the 

--- a/documentation/1.2/faq/language-design.md
+++ b/documentation/1.2/faq/language-design.md
@@ -350,7 +350,7 @@ goal of the language.
 
 The "best" default is the _most restrictive_ option. Otherwise,
 the developer of a module might accidently make something
-something shared that they don't intend to make shared, and
+shared that they don't intend to make shared, and
 be forced to either continue to support the 
 unintentionally-shared operation for the rest of the life of 
 the module, or break clients. There would be nothing the 

--- a/documentation/1.3/faq/language-design.md
+++ b/documentation/1.3/faq/language-design.md
@@ -350,7 +350,7 @@ goal of the language.
 
 The "best" default is the _most restrictive_ option. Otherwise,
 the developer of a module might accidently make something
-something shared that they don't intend to make shared, and
+shared that they don't intend to make shared, and
 be forced to either continue to support the 
 unintentionally-shared operation for the rest of the life of 
 the module, or break clients. There would be nothing the 


### PR DESCRIPTION
Grammar error: The word "something" was duplicated. Mistakenly I think.