### PR TITLE
More small fixes to annotation reference documentation

### DIFF
--- a/documentation/1.1/reference/annotation/doc.md
+++ b/documentation/1.1/reference/annotation/doc.md
@@ -45,6 +45,6 @@ The anonymous form is very strongly preferred.
 
 ## See also
 
-* [`doc`](#{site.urls.apidoc_1_1}/index.html#doc)
+* API documentation for [`doc`](#{site.urls.apidoc_1_1}/index.html#doc)
 * Reference for [annotations in general](../../structure/annotation/)
 

--- a/documentation/1.1/reference/annotation/license.md
+++ b/documentation/1.1/reference/annotation/license.md
@@ -30,6 +30,6 @@ than a license name (which might be ambiguous or unknown to the reader).
 
 ## See also
 
-* [`license`](#{site.urls.apidoc_1_1}/index.html#license)
+* API documentation for [`license`](#{site.urls.apidoc_1_1}/index.html#license)
 * Reference for [annotations in general](../../structure/annotation/)
 

--- a/documentation/1.1/reference/annotation/native.md
+++ b/documentation/1.1/reference/annotation/native.md
@@ -28,6 +28,6 @@ general use.
 
 ## See also
 
-* [`native`](#{site.urls.apidoc_1_1}/index.html#native)
+* API documentation for [`native`](#{site.urls.apidoc_1_1}/index.html#native)
 * Reference for [annotations in general](../../structure/annotation/)
 

--- a/documentation/1.1/reference/annotation/optional.md
+++ b/documentation/1.1/reference/annotation/optional.md
@@ -26,6 +26,6 @@ is available, but no error will occur if it is not available.
 
 ## See also
 
-* [`optional`](#{site.urls.apidoc_1_1}/index.html#optional)
+* API documentation for [`optional`](#{site.urls.apidoc_1_1}/index.html#optional)
 * Reference for [annotations in general](../../structure/annotation/)
 

--- a/documentation/1.1/reference/annotation/see.md
+++ b/documentation/1.1/reference/annotation/see.md
@@ -33,5 +33,5 @@ The `see` annotation is processed by the `ceylon doc` tool.
 
 ## See also
 
-* [`see`](#{site.urls.apidoc_1_1}/index.html#see)
+* API documentation for [`see`](#{site.urls.apidoc_1_1}/index.html#see)
 * Reference for [annotations in general](../../structure/annotation/)

--- a/documentation/1.1/reference/annotation/tagged.md
+++ b/documentation/1.1/reference/annotation/tagged.md
@@ -31,6 +31,6 @@ Its content should be a short keyword or identifier, and
 
 ## See also
 
-* [`tagged`](#{site.urls.apidoc_1_1}/index.html#tagged)
+* API documentation for [`tagged`](#{site.urls.apidoc_1_1}/index.html#tagged)
 * Reference for [annotations in general](../../structure/annotation/)
 

--- a/documentation/1.1/reference/annotation/throws.md
+++ b/documentation/1.1/reference/annotation/throws.md
@@ -34,6 +34,6 @@ Its `description` is assumed to contain [Markdown formatted](../markdown/) text.
 
 ## See also
 
-* [`throws`](#{site.urls.apidoc_1_1}/index.html#throws)
+* API documentation for [`throws`](#{site.urls.apidoc_1_1}/index.html#throws)
 * Reference for [annotations in general](../../structure/annotation/)
 

--- a/documentation/1.1/reference/annotation/variable.md
+++ b/documentation/1.1/reference/annotation/variable.md
@@ -32,5 +32,5 @@ assigned multiple times.
 
 ## See also
 
-* [`variable`](#{site.urls.apidoc_1_1}/index.html#variable)
+* API documentation for [`variable`](#{site.urls.apidoc_1_1}/index.html#variable)
 * Reference for [annotations in general](../../structure/annotation/)

--- a/documentation/1.2/reference/annotation/aliased.md
+++ b/documentation/1.2/reference/annotation/aliased.md
@@ -31,5 +31,6 @@ to the declaration name.
 
 ## See also
 
+* API documentation for [`aliased`](#{site.urls.apidoc_1_2}/index.html#aliased)
 * Reference for [annotations in general](../../structure/annotation/)
 

--- a/documentation/1.2/reference/annotation/doc.md
+++ b/documentation/1.2/reference/annotation/doc.md
@@ -45,6 +45,6 @@ The anonymous form is very strongly preferred.
 
 ## See also
 
-* [`doc`](#{site.urls.apidoc_1_2}/index.html#doc)
+* API documentation for [`doc`](#{site.urls.apidoc_1_2}/index.html#doc)
 * Reference for [annotations in general](../../structure/annotation/)
 

--- a/documentation/1.2/reference/annotation/license.md
+++ b/documentation/1.2/reference/annotation/license.md
@@ -30,6 +30,6 @@ than a license name (which might be ambiguous or unknown to the reader).
 
 ## See also
 
-* [`license`](#{site.urls.apidoc_1_2}/index.html#license)
+* API documentation for [`license`](#{site.urls.apidoc_1_2}/index.html#license)
 * Reference for [annotations in general](../../structure/annotation/)
 

--- a/documentation/1.2/reference/annotation/native.md
+++ b/documentation/1.2/reference/annotation/native.md
@@ -55,6 +55,6 @@ a specific backend so it can use features specific to that backend.
 ## See also
 
 * [How to use native annotations](../../interoperability/native)
-* [`native`](#{site.urls.apidoc_1_2}/index.html#native) documentation
+* API documentation for [`native`](#{site.urls.apidoc_1_2}/index.html#native) documentation
 * Reference for [annotations in general](../../structure/annotation/)
 

--- a/documentation/1.2/reference/annotation/optional.md
+++ b/documentation/1.2/reference/annotation/optional.md
@@ -26,6 +26,6 @@ is available, but no error will occur if it is not available.
 
 ## See also
 
-* [`optional`](#{site.urls.apidoc_1_2}/index.html#optional)
+* API documentation for [`optional`](#{site.urls.apidoc_1_2}/index.html#optional)
 * Reference for [annotations in general](../../structure/annotation/)
 

--- a/documentation/1.2/reference/annotation/see.md
+++ b/documentation/1.2/reference/annotation/see.md
@@ -33,5 +33,5 @@ The `see` annotation is processed by the `ceylon doc` tool.
 
 ## See also
 
-* [`see`](#{site.urls.apidoc_1_2}/index.html#see)
+* API documentation for [`see`](#{site.urls.apidoc_1_2}/index.html#see)
 * Reference for [annotations in general](../../structure/annotation/)

--- a/documentation/1.2/reference/annotation/serializable.md
+++ b/documentation/1.2/reference/annotation/serializable.md
@@ -27,6 +27,6 @@ externalized to a `Deconstructor`, and to initialize an instance from a
 
 ## See also
 
-* [`serializable`](#{site.urls.apidoc_1_2}/index.html#serializable)
+* API documentation for [`serializable`](#{site.urls.apidoc_1_2}/index.html#serializable)
 * Reference for [annotations in general](../../structure/annotation/)
 

--- a/documentation/1.2/reference/annotation/suppressWarnings.md
+++ b/documentation/1.2/reference/annotation/suppressWarnings.md
@@ -37,6 +37,6 @@ making warnings disappear: Its use should be considered on each occasion.
 
 ## See also
 
-* [`suppressWarnings`](#{site.urls.apidoc_1_2}/index.html#suppressWarnings)
+* API documentation for [`suppressWarnings`](#{site.urls.apidoc_1_2}/index.html#suppressWarnings)
 * Reference for [annotations in general](../../structure/annotation/)
 

--- a/documentation/1.2/reference/annotation/tagged.md
+++ b/documentation/1.2/reference/annotation/tagged.md
@@ -31,6 +31,6 @@ Its content should be a short keyword or identifier, and
 
 ## See also
 
-* [`tagged`](#{site.urls.apidoc_1_2}/index.html#tagged)
+* API documentation for [`tagged`](#{site.urls.apidoc_1_2}/index.html#tagged)
 * Reference for [annotations in general](../../structure/annotation/)
 

--- a/documentation/1.2/reference/annotation/throws.md
+++ b/documentation/1.2/reference/annotation/throws.md
@@ -34,6 +34,6 @@ Its `description` is assumed to contain [Markdown formatted](../markdown/) text.
 
 ## See also
 
-* [`throws`](#{site.urls.apidoc_1_2}/index.html#throws)
+* API documentation for [`throws`](#{site.urls.apidoc_1_2}/index.html#throws)
 * Reference for [annotations in general](../../structure/annotation/)
 

--- a/documentation/1.2/reference/annotation/variable.md
+++ b/documentation/1.2/reference/annotation/variable.md
@@ -32,5 +32,5 @@ assigned multiple times.
 
 ## See also
 
-* [`variable`](#{site.urls.apidoc_1_2}/index.html#variable)
+* API documentation for [`variable`](#{site.urls.apidoc_1_2}/index.html#variable)
 * Reference for [annotations in general](../../structure/annotation/)

--- a/documentation/1.3/reference/annotation/doc.md
+++ b/documentation/1.3/reference/annotation/doc.md
@@ -45,6 +45,6 @@ The anonymous form is very strongly preferred.
 
 ## See also
 
-* [`doc`](#{site.urls.apidoc_1_3}/index.html#doc)
+* API documentation for [`doc`](#{site.urls.apidoc_1_3}/index.html#doc)
 * Reference for [annotations in general](../../structure/annotation/)
 

--- a/documentation/1.3/reference/annotation/license.md
+++ b/documentation/1.3/reference/annotation/license.md
@@ -30,6 +30,6 @@ than a license name (which might be ambiguous or unknown to the reader).
 
 ## See also
 
-* [`license`](#{site.urls.apidoc_1_3}/index.html#license)
+* API documentation for [`license`](#{site.urls.apidoc_1_3}/index.html#license)
 * Reference for [annotations in general](../../structure/annotation/)
 

--- a/documentation/1.3/reference/annotation/native.md
+++ b/documentation/1.3/reference/annotation/native.md
@@ -55,6 +55,6 @@ a specific backend so it can use features specific to that backend.
 ## See also
 
 * [How to use native annotations](../../interoperability/native)
-* [`native`](#{site.urls.apidoc_1_3}/index.html#native) documentation
+* API documentation for [`native`](#{site.urls.apidoc_1_3}/index.html#native)
 * Reference for [annotations in general](../../structure/annotation/)
 

--- a/documentation/1.3/reference/annotation/optional.md
+++ b/documentation/1.3/reference/annotation/optional.md
@@ -26,6 +26,6 @@ is available, but no error will occur if it is not available.
 
 ## See also
 
-* [`optional`](#{site.urls.apidoc_1_3}/index.html#optional)
+* API documentation for [`optional`](#{site.urls.apidoc_1_3}/index.html#optional)
 * Reference for [annotations in general](../../structure/annotation/)
 

--- a/documentation/1.3/reference/annotation/see.md
+++ b/documentation/1.3/reference/annotation/see.md
@@ -33,5 +33,5 @@ The `see` annotation is processed by the `ceylon doc` tool.
 
 ## See also
 
-* [`see`](#{site.urls.apidoc_1_3}/index.html#see)
+* API documentation for [`see`](#{site.urls.apidoc_1_3}/index.html#see)
 * Reference for [annotations in general](../../structure/annotation/)

--- a/documentation/1.3/reference/annotation/serializable.md
+++ b/documentation/1.3/reference/annotation/serializable.md
@@ -27,6 +27,6 @@ externalized to a `Deconstructor`, and to initialize an instance from a
 
 ## See also
 
-* [`serializable`](#{site.urls.apidoc_1_3}/index.html#serializable)
+* API documentation for [`serializable`](#{site.urls.apidoc_1_3}/index.html#serializable)
 * Reference for [annotations in general](../../structure/annotation/)
 

--- a/documentation/1.3/reference/annotation/suppressWarnings.md
+++ b/documentation/1.3/reference/annotation/suppressWarnings.md
@@ -37,6 +37,6 @@ making warnings disappear: Its use should be considered on each occasion.
 
 ## See also
 
-* [`suppressWarnings`](#{site.urls.apidoc_1_3}/index.html#suppressWarnings)
+* API documentation for [`suppressWarnings`](#{site.urls.apidoc_1_3}/index.html#suppressWarnings)
 * Reference for [annotations in general](../../structure/annotation/)
 

--- a/documentation/1.3/reference/annotation/tagged.md
+++ b/documentation/1.3/reference/annotation/tagged.md
@@ -31,6 +31,6 @@ Its content should be a short keyword or identifier, and
 
 ## See also
 
-* [`tagged`](#{site.urls.apidoc_1_3}/index.html#tagged)
+* API documentation for [`tagged`](#{site.urls.apidoc_1_3}/index.html#tagged)
 * Reference for [annotations in general](../../structure/annotation/)
 

--- a/documentation/1.3/reference/annotation/throws.md
+++ b/documentation/1.3/reference/annotation/throws.md
@@ -34,6 +34,6 @@ Its `description` is assumed to contain [Markdown formatted](../markdown/) text.
 
 ## See also
 
-* [`throws`](#{site.urls.apidoc_1_3}/index.html#throws)
+* API documentation for [`throws`](#{site.urls.apidoc_1_3}/index.html#throws)
 * Reference for [annotations in general](../../structure/annotation/)
 

--- a/documentation/1.3/reference/annotation/variable.md
+++ b/documentation/1.3/reference/annotation/variable.md
@@ -32,5 +32,5 @@ assigned multiple times.
 
 ## See also
 
-* [`variable`](#{site.urls.apidoc_1_3}/index.html#variable)
+* API documentation for [`variable`](#{site.urls.apidoc_1_3}/index.html#variable)
 * Reference for [annotations in general](../../structure/annotation/)


### PR DESCRIPTION
Not all links to annotation api documantation were formatted similarily. I fixed the few odd references t, so that all have same wording now.