### PR TITLE
Double backticks should be escaped instead of single backticks

### DIFF
--- a/documentation/1.3/reference/literal/string.md
+++ b/documentation/1.3/reference/literal/string.md
@@ -37,7 +37,7 @@ used within a plain `String` literal:
 
 * backslash, `\`, must be written as `\\`
 * double quote, `"`, must be written as `\"`
-* backtick, `` ` ``, must be written as `` \` ``
+* double backticks, ``` `` ```, must be written as ``` \`` ```
 
 In a plain `String` literal, the following traditional C-style escape sequences 
 are also supported:


### PR DESCRIPTION
The (reference)[https://ceylon-lang.org/documentation/reference/literal/string/] states currently that backticks have to be escaped, but 
```
print("Hello `world`");
```
**does** print `` "Hello `world` ``. According to Section 2.4.3 ("String literals") of the (language specification)[https://ceylon-lang.org/documentation/1.3/spec/pdf/ceylon-language-specification.pdf], A sequence of two backticks is used to delimit an interpolated expression embedded in a string template. Therefore, double backticks should be escaped instead.

See issue #455 