### PR TITLE
Corrected example for `service` annotation

### DIFF
--- a/documentation/1.3/tour/modules.md
+++ b/documentation/1.3/tour/modules.md
@@ -583,7 +583,7 @@ Here, `DefaultManager` is declared as a service provider for
 the service type `Manager`: 
 
 <!-- try: -->
-     service (`Manager`)
+     service (`interface Manager`)
      shared class DefaultManager() satisfies Manager {}
  
 Typically, the service type, service provider, and the client


### PR DESCRIPTION
it expects a declaration, not a type.

fixes https://github.com/ceylon/ceylon-lang.org/issues/490

I'm not sure if this PR should be against master or 1.3.3?